### PR TITLE
Fix bug in the kapture_import_bundler.py

### DIFF
--- a/tools/kapture_import_bundler.py
+++ b/tools/kapture_import_bundler.py
@@ -196,7 +196,7 @@ def import_bundler(bundler_path: str,
         # finally, convert local_keypoints to np.ndarray and add them to the global keypoints variable
         keypoints = kapture.Keypoints('sift', np.float32, 2)
         for image_filename, keypoints_array in local_keypoints.items():
-            keypoints_np_array = np.array(keypoints_array)
+            keypoints_np_array = np.array(keypoints_array).astype(np.float32)
             keypoints_out_path = kapture.io.features.get_keypoints_fullpath(kapture_dir_path, image_filename)
             kapture.io.features.image_keypoints_to_file(keypoints_out_path, keypoints_np_array)
             keypoints.add(image_filename)


### PR DESCRIPTION
Fix the data precision. Otherwise the np.array generates np.float64 array by default, which leads to completely wrongly read data.

 An example:

keypoints of "IMG_9614.MOV_frame000100.png" as numpy array of float32 and shape (5304, 2):

> [[ 0.00000000e+00  4.25390625e+00]
>  [-1.07374184e+08  4.08701134e+00]
>  [ 0.00000000e+00  4.62646484e+00]
>  ...
>  [ 0.00000000e+00  3.49609375e+00]
>  [ 0.00000000e+00  4.24218750e+00]
>  [ 0.00000000e+00  3.73046875e+00]]

After modification:

> array([1102.,  117., 1213., ...,  720., 1195.,  710.], dtype=float32)