### PR TITLE
Jmorat

### DIFF
--- a/kapture/converter/downloader/archives.py
+++ b/kapture/converter/downloader/archives.py
@@ -20,7 +20,8 @@ def untar_file(archive_filepath: str,
     # make sure directory exists
     os.makedirs(install_dirpath, exist_ok=True)
     with tarfile.open(archive_filepath, 'r:*') as archive:
-        archive.extractall(install_dirpath)
+        for tarinfo in archive:
+            archive.extract(tarinfo, path=install_dirpath, set_attrs=False)
 
 
 def compute_sha256sum(archive_filepath: str):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -40,6 +40,7 @@ SLOW_TESTS = os.environ.get('SLOW_TESTS', False)
 
 
 class TestDownloaderPermissions(unittest.TestCase):
+    @unittest.skipIf(sys.platform.startswith("win"), "not handling permissions on Windows")
     def setUp(self):
         self._tempdir = tempfile.TemporaryDirectory()
         # make up a read only file

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -44,25 +44,25 @@ class TestDownloaderPermissions(unittest.TestCase):
         self._tempdir = tempfile.TemporaryDirectory()
         # make up a read only file
         os.chdir(self._tempdir.name)
-        self.tocompress_filename = 'toto.txt'
-        with open(self.tocompress_filename, 'wt') as f:
-            f.write('toto')
-        os.chmod(self.tocompress_filename, stat.S_IRUSR)
+        self.test_filename = 'permission_check.txt'
+        with open(self.test_filename, 'wt') as f:
+            f.write('permission')
+        os.chmod(self.test_filename, stat.S_IRUSR)
         # tar it
         self.tar_filepath = path.join(self._tempdir.name, 'archive.tar')
         with tarfile.open(self.tar_filepath, 'w:gz') as tar:
-            tar.add(self.tocompress_filename)
-        # self._debug = tocompress_filepath
-        os.remove(self.tocompress_filename)
+            tar.add(self.test_filename)
+        os.remove(self.test_filename)
 
     def tearDown(self) -> None:
         self._tempdir.cleanup()
 
     def test_extract_permissions(self):
-        print(self.tar_filepath)
-        print(self.tocompress_filename)
-        archives.untar_file(archive_filepath=self.tar_filepath, install_dirpath=self._tempdir)
-        a = self._debug
+        os.chdir(self._tempdir.name)
+        archives.untar_file(archive_filepath=self.tar_filepath, install_dirpath=self._tempdir.name)
+        st = os.stat(self.test_filename)
+        self.assertTrue(st.st_mode & stat.S_IRUSR)
+        self.assertTrue(st.st_mode & stat.S_IWUSR)
 
 
 if __name__ == '__main__':

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -44,28 +44,28 @@ class TestDownloaderPermissions(unittest.TestCase):
     def setUp(self):
         self._tempdir = tempfile.TemporaryDirectory()
         # make up a read only file
-        os.chdir(self._tempdir.name)
-        self.test_dirname = 'permission_dir'
-        self.test_filename = path.join(self.test_dirname, 'permission_file.txt')
-        os.makedirs(self.test_dirname)
-        with open(self.test_filename, 'wt') as f:
+        test_dirname = 'permission_dir'
+        test_filename = path.join(test_dirname, 'permission_file.txt')
+        self.test_filepath = path.join(self._tempdir.name, test_filename)
+        self.test_dirpath = path.join(self._tempdir.name, test_dirname)
+        os.makedirs(self.test_dirpath)
+        with open(self.test_filepath, 'wt') as f:
             f.write('permission')
-        os.chmod(self.test_filename, stat.S_IRUSR)
+        os.chmod(self.test_filepath, stat.S_IRUSR)
         # tar it
         self.tar_filepath = path.join(self._tempdir.name, 'archive.tar')
         with tarfile.open(self.tar_filepath, 'w:gz') as tar:
-            tar.add(self.test_filename)
+            tar.add(self.test_filepath, arcname=test_filename)
         # clean
-        os.remove(self.test_filename)
-        os.rmdir(self.test_dirname)
+        os.remove(self.test_filepath)
+        os.rmdir(self.test_dirpath)
 
     def tearDown(self) -> None:
         self._tempdir.cleanup()
 
     def test_extract_permissions(self):
-        os.chdir(self._tempdir.name)
         archives.untar_file(archive_filepath=self.tar_filepath, install_dirpath=self._tempdir.name)
-        st = os.stat(self.test_filename)
+        st = os.stat(self.test_filepath)
         self.assertTrue(st.st_mode & stat.S_IRUSR)
         self.assertTrue(st.st_mode & stat.S_IWUSR)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -44,7 +44,9 @@ class TestDownloaderPermissions(unittest.TestCase):
         self._tempdir = tempfile.TemporaryDirectory()
         # make up a read only file
         os.chdir(self._tempdir.name)
-        self.test_filename = 'permission_check.txt'
+        self.test_dirname = 'permission_dir'
+        self.test_filename = path.join(self.test_dirname, 'permission_file.txt')
+        os.makedirs(self.test_dirname)
         with open(self.test_filename, 'wt') as f:
             f.write('permission')
         os.chmod(self.test_filename, stat.S_IRUSR)
@@ -52,7 +54,9 @@ class TestDownloaderPermissions(unittest.TestCase):
         self.tar_filepath = path.join(self._tempdir.name, 'archive.tar')
         with tarfile.open(self.tar_filepath, 'w:gz') as tar:
             tar.add(self.test_filename)
+        # clean
         os.remove(self.test_filename)
+        os.rmdir(self.test_dirname)
 
     def tearDown(self) -> None:
         self._tempdir.cleanup()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,10 +3,14 @@
 
 import unittest
 import os
-# import os.path as path
-# import sys
+import tempfile
+import tarfile
+import os.path as path
+import sys
+import stat
 # kapture
-# import path_to_kapture  # enables import kapture  # noqa: F401
+import path_to_kapture  # enables import kapture  # noqa: F401
+import kapture.converter.downloader.archives as archives
 # import tools.kapture_download_dataset as download
 # from unittest.mock import patch
 
@@ -33,7 +37,33 @@ SLOW_TESTS = os.environ.get('SLOW_TESTS', False)
 #         test_args = ["downloader", "--install_path", self.dataset_dir, "list", "--full"]
 #         with patch.object(sys, 'argv', test_args):
 #             self.assertEqual(download.kapture_download_dataset_cli(), 0)
-#
+
+
+class TestDownloaderPermissions(unittest.TestCase):
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        # make up a read only file
+        os.chdir(self._tempdir.name)
+        self.tocompress_filename = 'toto.txt'
+        with open(self.tocompress_filename, 'wt') as f:
+            f.write('toto')
+        os.chmod(self.tocompress_filename, stat.S_IRUSR)
+        # tar it
+        self.tar_filepath = path.join(self._tempdir.name, 'archive.tar')
+        with tarfile.open(self.tar_filepath, 'w:gz') as tar:
+            tar.add(self.tocompress_filename)
+        # self._debug = tocompress_filepath
+        os.remove(self.tocompress_filename)
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def test_extract_permissions(self):
+        print(self.tar_filepath)
+        print(self.tocompress_filename)
+        archives.untar_file(archive_filepath=self.tar_filepath, install_dirpath=self._tempdir)
+        a = self._debug
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/kapture_download_dataset.py
+++ b/tools/kapture_download_dataset.py
@@ -24,6 +24,7 @@ from kapture.converter.downloader.archives import untar_file, compute_sha256sum
 from kapture.io.csv import get_version_from_csv_file
 from kapture.utils.upgrade import upgrade_1_0_to_1_1_inplace, upgrade_1_0_to_1_1_orphan_features
 
+
 logger = logging.getLogger('downloader')
 logging.basicConfig(format='%(levelname)-8s::%(name)s: %(message)s')
 


### PR DESCRIPTION
Ignore permissions/ownership/timestamps from datasets archives, to avoid overwrite error for duplicated license file.