### PR TITLE
replace deprecated np.float and np.int with builtins

### DIFF
--- a/kapture/converter/colmap/import_colmap_database.py
+++ b/kapture/converter/colmap/import_colmap_database.py
@@ -295,7 +295,7 @@ def get_matches_from_database(database: COLMAPDatabase,
 
         # actually write the file
         # convert colmap image matches into kapture (cast to float and add a score column)
-        image_matches = image_matches.astype(np.float)
+        image_matches = image_matches.astype(float)
         image_matches = np.hstack([image_matches, np.zeros((image_matches.shape[0], 1))])
         image_matches_filepath = kapture.io.features.get_matches_fullpath((filename1, filename2),
                                                                           keypoints_type,

--- a/kapture/converter/openmvg/import_openmvg.py
+++ b/kapture/converter/openmvg/import_openmvg.py
@@ -525,7 +525,7 @@ def _import_openmvg_matches(
             swap_order = image_2 < image_1
             line = fid.readline()
             num_matches = int(line.rstrip('\r\n'))
-            matches_array = np.empty((num_matches, 3), dtype=np.float)
+            matches_array = np.empty((num_matches, 3), dtype=float)
             for i in range(num_matches):
                 line = fid.readline()
                 splits_kpts_idx = line.rstrip('\r\n').split()

--- a/kapture/converter/opensfm/export_opensfm.py
+++ b/kapture/converter/opensfm/export_opensfm.py
@@ -276,7 +276,7 @@ def _export_opensfm_features_and_matches(image_filenames,
                     kapture_dirpath=kapture_root_dir,
                     tar_handler=tar_handlers)
                 kapture_matches = image_matches_from_file(kapture_matches_filepath)
-                opensfm_matches[image_filename2] = kapture_matches[:, 0:2].astype(np.int)
+                opensfm_matches[image_filename2] = kapture_matches[:, 0:2].astype(int)
 
             os.makedirs(path.dirname(opensfm_matches_filepath), exist_ok=True)
             with gzip.open(opensfm_matches_filepath, 'wb') as f:

--- a/kapture/io/csv.py
+++ b/kapture/io/csv.py
@@ -23,7 +23,6 @@ from kapture.io.tar import get_feature_tar_fullpath, retrieve_tar_handler_from_c
 
 logger = kapture.logger
 
-np.float = float  # monkey patch
 
 # file names conventions
 CSV_FILENAMES = {
@@ -1265,7 +1264,7 @@ def points3d_from_file(filepath: str) -> kapture.Points3d:
                 else:
                     expected_nb_columns = kapture.Points3d.XYZ_ONLY
     # Load
-    data = np.loadtxt(filepath, dtype=np.float, delimiter=',', comments='#')
+    data = np.loadtxt(filepath, dtype=float, delimiter=',', comments='#')
     if len(data) > 0:
         if len(data.shape) == 1:
             found_nb_columns = data.shape[0]

--- a/kapture/io/ply.py
+++ b/kapture/io/ply.py
@@ -56,7 +56,7 @@ def get_axis_in_world(
         [length, 0, 0],  # X
         [0, length, 0],  # Y
         [0, 0, length],  # Z
-    ], dtype=np.float)
+    ], dtype=float)
     return pose_device_from_world.inverse().transform_points(sensor_axis)
 
 

--- a/tools/kapture_import_4seasons.py
+++ b/tools/kapture_import_4seasons.py
@@ -448,7 +448,7 @@ def import_4seasons_imu(
     # Each line is specified as frame_id, (angular velocity (w_x, w_y, w_z), and linear acceleration (a_x, a_y, a_z)).
     # 1602074877342319360 -0.009163 0.018326 -0.070250 0.189211 0.860048 9.657110
     data = np.loadtxt(imu_file_path)
-    shot_ids = data[:, 0].astype(np.int).astype(str)
+    shot_ids = data[:, 0].astype(int).astype(str)
     rotation_speeds = data[:, 1:4]
     translation_accels = data[:, 4:7]
     for shot_id, (rx, ry, rz), (ax, ay, az) in zip(shot_ids, rotation_speeds, translation_accels):

--- a/tools/kapture_import_Extended_CMU_Seasons.py
+++ b/tools/kapture_import_Extended_CMU_Seasons.py
@@ -163,7 +163,7 @@ def import_extended_cmu_seasons_images(image_list_file_path: str) -> Tuple[kaptu
             rotation = quaternion.from_float_array(quaternion_array)
             # C = -R^T * t -> t = -R * C
             translation = np.matmul(quaternion.as_rotation_matrix(rotation),
-                                    -1 * np.array(center_array, dtype=np.float))
+                                    -1 * np.array(center_array, dtype=float))
             pose = kapture.PoseTransform(r=rotation, t=translation)
             trajectories[(timestamp, camera_id)] = pose
 

--- a/tools/kapture_import_image_list_with_poses.py
+++ b/tools/kapture_import_image_list_with_poses.py
@@ -120,7 +120,7 @@ def import_image_list_with_poses(images_list_file_path: str,
             if qw != '' and qx != '' and qy != '' and qz != '':
                 rotation = quaternion.from_float_array([float(qw), float(qx), float(qy), float(qz)])
             if tx != '' and ty != '' and tz != '':
-                translation = np.array([[float(tx)], [float(ty)], [float(tz)]], dtype=np.float)
+                translation = np.array([[float(tx)], [float(ty)], [float(tz)]], dtype=float)
             pose = kapture.PoseTransform(rotation, translation)
             trajectories[(int(timestamp), camera_id)] = pose
 

--- a/tools/kapture_import_silda.py
+++ b/tools/kapture_import_silda.py
@@ -89,7 +89,7 @@ def _import_trajectories(silda_dir_path, image_name_to_ids, hide_progress_bars) 
         lines = file.readlines()
         lines = (line.rstrip().split() for line in lines)
         extrinsics = {
-            line[0]: np.array(line[1:8], dtype=np.float) for line in lines
+            line[0]: np.array(line[1:8], dtype=float) for line in lines
         }
     for silda_image_name, pose_params in tqdm(extrinsics.items(), disable=hide_progress_bars):
         # Silda poses are 7-dim vectors with the rotation quaternion,


### PR DESCRIPTION
np.float, np.int etc were removed in numpy 1.24 — these should just be the python builtins. also removed the monkey patch in csv.py that was working around this.